### PR TITLE
Update Arch Linux instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ Enjoy!
 
 ### Install from AUR
 
-You can use your favorite [AUR helper](https://wiki.archlinux.org/title/AUR_helpers) to install. For example,
+You can use [pacman](https://wiki.archlinux.org/title/pacman) to install:
 
 ```shell
-paru -S atac
+pacman -S atac
 ```
 
 Enjoy!

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ atac -h
 
 Enjoy!
 
-### Install from AUR
+### Install from Arch
 
 You can use [pacman](https://wiki.archlinux.org/title/pacman) to install:
 


### PR DESCRIPTION
I moved `ATAC` to the official repositories: <https://archlinux.org/packages/extra/x86_64/atac> 🥳
