### PR TITLE
Change vim key bindings

### DIFF
--- a/key_bindings_templates/vim_key_bindings.toml
+++ b/key_bindings_templates/vim_key_bindings.toml
@@ -18,13 +18,13 @@ display_help = "Shift-h" # Take care to not overlap other inputs, the help can b
 # Collection name, request name, URL, Header, Query param, Basic Auth, Bearer Token
 [keybindings.generic.text_inputs.text_input]
 cancel = "Esc"
-validate = "Ctrl-s"
+validate = "Enter"
 
 delete_backward = "Delete"
-delete_forward = "x"
+delete_forward = "Backspace"
 
-move_cursor_left = "Ctrl-h"
-move_cursor_right = "Ctrl-l"
+move_cursor_left = "Left"
+move_cursor_right = "Right"
 
 # Request body
 [keybindings.generic.text_inputs]
@@ -46,7 +46,7 @@ select = "Enter"
 [keybindings.generic.list_and_table_actions]
 create_element = "n"
 delete_element = "d"
-edit_element = "c" # Edit query param, header, basic auth, bearer token
+edit_element = "i" # Edit query param, header, basic auth, bearer token
 rename_element = "r" # Only used in the collections list (main menu)
 toggle_element = "t" # Only used in tables (Query params, headers, cookies)
 
@@ -67,8 +67,8 @@ change_auth_method = "Shift-A"
 change_body_content_type = "Shift-B"
 
 [keybindings.request_selected.result_tabs]
-scroll_up = "Ctrl-y"
-scroll_down = "Ctrl-e"
+scroll_up = "Ctrl-k"
+scroll_down = "Ctrl-j"
 scroll_left = "Ctrl-h"
 scroll_right = "Ctrl-l"
 


### PR DESCRIPTION
This is regarding issue #10 

I change some key bindings based on my vim experience.

I notice that you're trying to map everything to vim key bindings. But it's not the point. Vim users generally just want to use vim motions when moving around. But when editing, you should leave everything normal.
