### PR TITLE
Draft implementation of curl file import 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
+
+[[package]]
 name = "arboard"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +131,12 @@ dependencies = [
  "windows-sys 0.48.0",
  "x11rb",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-compression"
@@ -155,6 +167,7 @@ dependencies = [
  "lazy_static",
  "nestify",
  "parse_postman_collection",
+ "parser4curls",
  "ratatui",
  "regex",
  "reqwest",
@@ -218,6 +231,18 @@ name = "bitflags"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+
+[[package]]
+name = "bitvec"
+version = "0.19.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55f93d0ef3363c364d5976646a38f04cf67cfe1d4c8d160cdea02cab2c116b33"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block"
@@ -701,6 +726,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,6 +1061,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,6 +1194,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "nom"
+version = "6.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+dependencies = [
+ "bitvec",
+ "funty",
+ "lexical-core",
+ "memchr",
+ "version_check",
 ]
 
 [[package]]
@@ -1279,6 +1336,17 @@ dependencies = [
  "serde_yaml",
  "url 2.5.0",
  "url_serde",
+]
+
+[[package]]
+name = "parser4curls"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d5240eaa2d22c40fbd8e33bfa6662a0e7d7c86515dbcc92b0fc00bd1c2cb0"
+dependencies = [
+ "anyhow",
+ "nom",
+ "serde_json",
 ]
 
 [[package]]
@@ -1422,6 +1490,12 @@ checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -1994,6 +2068,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
@@ -2635,6 +2715,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "x11rb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ jsonxf = "1.1.1"
 toml = "0.8.11"
 envfile = "0.2.1"
 parse_postman_collection = "0.2.3"
+parser4curls = "0.1"
 clap = { version = "4.5.0", features = ["derive", "color"] }
 arboard = "3.3.2"
 tokio = { version = "1.36.0", features = ["rt", "rt-multi-thread", "macros"] }

--- a/src/app/files/curl.rs
+++ b/src/app/files/curl.rs
@@ -1,0 +1,138 @@
+use std::fs;
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
+
+use parser4curls::{parse, Curl};
+use reqwest::Url;
+
+use crate::app::app::App;
+use crate::app::startup::args::ARGS;
+use crate::panic_error;
+use crate::request::auth::Auth;
+use crate::request::body::ContentType;
+use crate::request::collection::Collection;
+use crate::request::method::Method;
+use crate::request::request::{KeyValue, Request};
+
+impl App<'_> {
+    pub fn import_curl_file(&mut self, path_buf: &PathBuf) {
+        println!("Parsing curl file");
+
+        let original_curl = match fs::read_to_string(path_buf) {
+            Ok(original_curl) => original_curl,
+            Err(e) => panic_error(format!("Could not read cURL file\n\t{e}")),
+        };
+
+        let curl = match parse(original_curl.as_str()) {
+            // The first element is the curl command - for now we only support one per file
+            Ok(curl) => curl.1,
+            Err(e) => panic_error(format!("Could not parse cURL\n\t{e}")),
+        };
+
+        let req_name = path_buf.file_name().unwrap().to_str().unwrap().to_string();
+
+        // We will check if theres an 'imported collection', if so we will append, else create
+        let imported_exists = self.collections.iter().any(|c| c.name == "imported");
+
+        if imported_exists {
+            let imported = self
+                .collections
+                .iter_mut()
+                .find(|c| c.name == "imported")
+                .unwrap();
+            imported.requests.push(Arc::new(RwLock::new(parse_request(&curl, req_name))));
+        } else {
+            let collection = Collection {
+                name: "imported".to_string(),
+                requests: vec![Arc::new(RwLock::new(parse_request(&curl, req_name)))],
+                path: ARGS.directory.join("imported.json"),
+            };
+
+            self.collections.push(collection);
+        }
+
+        let imported_index = self.collections.iter().position(|c| c.name == "imported").unwrap();
+        self.save_collection_to_file(imported_index);
+    }
+}
+
+fn parse_request(curl: &Curl, req_name: String) -> Request {
+    print!("Found cURL: {:?}", curl);
+
+    let mut request = Request::default();
+
+    request.name = req_name;
+
+    // Parse the URL so we can transform it
+    let mut curl_url = match Url::parse(curl.url) {
+        Ok(url) => url,
+        Err(e) => panic_error(format!("Could not parse URL\n\t{e}")),
+    };
+
+
+    /* QUERY PARAMS */
+
+    request.params = curl_url
+        .query_pairs()
+        .map(|(k, v)| KeyValue {
+            enabled: true,
+            data: (k.to_string(), v.to_string()),
+        })
+        .collect();
+    
+    /* URL */
+
+    curl_url.set_query(None);
+    request.url = curl_url.to_string();
+
+    /* METHOD */
+
+    request.method = get_http_method(&curl);
+
+    /* HEADERS */
+
+    request.headers = curl
+        .options_headers_more
+        .iter()
+        .filter(|&(k, _)| !k.eq_ignore_ascii_case("Authorization")) // Exclude Authorization header, as that will be handled by the auth field
+        .map(|(k, v)| KeyValue {
+            enabled: true,
+            data: (k.to_string(), v.to_string()),
+        })
+    .collect();
+
+    /* AUTH */
+
+    if let Some(auth) = curl.options_more.get("u") {
+        let parts: Vec<&str> = auth.splitn(2, ':').collect();
+        if parts.len() == 2 {
+            request.auth = Auth::BasicAuth(parts[0].to_string(), parts[1].to_string());
+        }
+    } else if let Some(auth) = curl.options_headers_more.get("Authorization") {
+        let parts: Vec<&str> = auth.split_whitespace().collect();
+        if parts.len() > 1 && parts[0].starts_with("Bearer") {
+            request.auth = Auth::BearerToken(parts[1].to_string());
+        }
+    }
+
+    /* BODY */
+
+    // TODO: Handle content type
+    request.body = ContentType::Raw(curl.options_data_raw.to_string());
+
+    request
+}
+
+fn get_http_method(curl: &Curl) -> Method {
+    if let Some(x) = curl.options_more.get("X") {
+        match x {
+            &"PUT" => Method::PUT,
+            &"DELETE" => Method::DELETE,
+            _ => Method::GET,
+        }
+    } else if !curl.options_data_raw.is_empty() {
+        Method::POST
+    } else {
+        Method::GET
+    }
+}

--- a/src/app/files/mod.rs
+++ b/src/app/files/mod.rs
@@ -4,3 +4,4 @@ pub mod log;
 pub mod config;
 pub mod key_bindings;
 mod postman;
+mod curl;

--- a/src/app/startup/args.rs
+++ b/src/app/startup/args.rs
@@ -21,7 +21,7 @@ pub struct Args {
 
 #[derive(Debug, Subcommand, PartialEq)]
 pub enum Command {
-    /// Used to import a collection file such as Postman
+    /// Used to import a collection file such as Postman, or a file containing a curl
     Import(ImportArgs),
 }
 

--- a/src/app/startup/startup.rs
+++ b/src/app/startup/startup.rs
@@ -18,11 +18,20 @@ impl App<'_> {
         if let Some(command) = &ARGS.command {
             match command {
                 Command::Import(import_args) => {
-                    self.import_postman_collection(&import_args.path, import_args.max_depth.unwrap_or(99));
+                    print!("Importing: {}", import_args.path.display());
+
+                    let extension = import_args.path.extension().unwrap_or_default().to_str().unwrap_or_default();
+                    if extension == "json" {
+                        // If the file is json, we attempt to import postman collection
+                        self.import_postman_collection(&import_args.path, import_args.max_depth.unwrap_or(99));
+                    } else {
+                        // We attempt to import a curl file
+                        self.import_curl_file(&import_args.path);
+                    }
                 }
             }
         }
-        
+
         self
     }
 


### PR DESCRIPTION
This is a WIP implementation of importing curl files into ATAC - requested in https://github.com/Julien-cpsn/ATAC/issues/48

It should support all browsers Copy > Copy as cURL dev function, and parse Bearer Tokens, headers, and URL params.

There are some points that should be discussed:
1. How should we handle a collection for imported curl requests? For now I have just allowed an 'imported' collection to be created or appended to.
2. For now the request name will be the name of the file that is being imported.
3. At the moment, only one curl req per file is supported, but I believe this can be extended quite easily.
4. I have supported curl import for ANY file type other than .json (which is for postman collection imports). Should we only support .curl for example?

There may be some cases I have missed as this is a very draft impl while the above are addressed.

Here is a demo: 

https://github.com/Julien-cpsn/ATAC/assets/39057715/b287762b-be2a-4b07-980b-ddee112d1082

Thanks!

