### PR TITLE
fix(quit): allow to quit atac inside selected requests

### DIFF
--- a/src/app/app_states.rs
+++ b/src/app/app_states.rs
@@ -270,6 +270,7 @@ impl AppState {
                 };
 
                 let mut base_events: Vec<AppEvent> = vec![
+                    ExitApp(EventKeyBinding::new(vec![key_bindings.main_menu.exit], "Exit", Some("Exit"))),
                     GoBackToMainMenu(EventKeyBinding::new(vec![key_bindings.generic.navigation.go_back], "Quit", Some("Quit"))),
                     Documentation(EventKeyBinding::new(vec![key_bindings.generic.display_help], "Display help", Some("Help"))),
 

--- a/src/app/files/key_bindings.rs
+++ b/src/app/files/key_bindings.rs
@@ -86,6 +86,7 @@ nest! {
         },
 
         pub request_selected: #[derive(Copy, Clone, Deserialize)] pub struct RequestSelected {
+            pub exit: KeyCombination,
             pub param_next_tab: KeyCombination,
             pub change_url: KeyCombination,
             pub change_method: KeyCombination,
@@ -205,6 +206,7 @@ impl Default for KeyBindings {
             },
 
             request_selected: RequestSelected {
+                exit: key!(q),
                 param_next_tab: key!(tab),
 
                 change_url: key!(u),


### PR DESCRIPTION
Proposal

I always find myself executing a request, copying the result, and trying to quit as soon as i copy the result.
But currently quitting with `q` only works in the "normal" view, so quitting requires `ctrl+c` or `Esc -> q`.
With this, you will be able to quit using `q` on a selected request.
Thanks!