### PR TITLE
Add support for home directory symbol `~` in file paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "shellexpand",
  "snailquote",
  "strum",
  "syntect",
@@ -837,6 +838,27 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1526,6 +1548,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+]
+
+[[package]]
 name = "line-wrap"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,6 +1855,12 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -2217,6 +2255,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2563,6 +2612,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,4 @@ snailquote = "0.3.1"
 indexmap = { version = "2.2.6", features = ["serde"] }
 base64 = "0.22.0"
 regex = "1.10.3"
+shellexpand = "3.1.0"

--- a/src/app/files/key_bindings.rs
+++ b/src/app/files/key_bindings.rs
@@ -9,6 +9,7 @@ use nestify::nest;
 use parking_lot::RwLock;
 use ratatui::text::Span;
 use serde::Deserialize;
+use shellexpand::tilde;
 
 use crate::app::app::App;
 use crate::panic_error;
@@ -272,7 +273,7 @@ impl App<'_> {
     pub fn parse_key_bindings_file(&mut self) {
         let path = match env::var("ATAC_KEY_BINDINGS") {
             // If the ATAC_KEY_BINDINGS environment variable exists
-            Ok(env_key_bindings) => PathBuf::from(env_key_bindings),
+            Ok(env_key_bindings) => PathBuf::from(tilde(&env_key_bindings).as_ref()),
             Err(_) => {
                 println!("No key bindings file found\n");
                 return;

--- a/src/app/startup/args.rs
+++ b/src/app/startup/args.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use clap::{Parser, Subcommand};
 use clap::builder::Styles;
 use lazy_static::lazy_static;
+use shellexpand::tilde;
 use crate::panic_error;
 
 #[derive(Parser, Debug)]
@@ -81,7 +82,7 @@ lazy_static! {
             // If no directory was provided with the CLI
             None => match env::var("ATAC_MAIN_DIR") {
                 // If the ATAC_MAIN_DIR environment variable exists
-                Ok(env_directory) => (PathBuf::from(env_directory), true),
+                Ok(env_directory) => (PathBuf::from(tilde(&env_directory).as_ref()), true),
                 Err(_) => panic_error("No directory provided, provide one either with `--directory <dir>` or via the environment variable `ATAC_MAIN_DIR`")
             }
         };


### PR DESCRIPTION
I discovered that `PathBuf` is unable to handle paths with the `~` symbol,. To address this, I used the `shellexpand` crate to expand the tilde to the actual home directory path.

If any changes are needed, please let me know. Thank you for maintaining this great repository!