### PR TITLE
Add "validate" field to keybindings example files

### DIFF
--- a/key_bindings_templates/default_key_bindings.toml
+++ b/key_bindings_templates/default_key_bindings.toml
@@ -26,6 +26,8 @@ delete_forward = "Backspace"
 move_cursor_left = "Left"
 move_cursor_right = "Right"
 
+validate = "Enter"
+
 # Request body
 [keybindings.generic.text_inputs.text_area_mode.Custom]
 quit_without_saving = "Esc"

--- a/key_bindings_templates/vim_key_bindings.toml
+++ b/key_bindings_templates/vim_key_bindings.toml
@@ -26,6 +26,8 @@ delete_forward = "Backspace"
 move_cursor_left = "Ctrl-h"
 move_cursor_right = "Ctrl-l"
 
+validate = "Enter"
+
 # Request body
 [keybindings.generic.text_inputs]
 


### PR DESCRIPTION
When loading keybinding file, I got a parser error because the "validate" field don't exist in the keybindings example files, so I added it to them.