### PR TITLE
fix:temporal fix for atac

### DIFF
--- a/src/app/startup/startup.rs
+++ b/src/app/startup/startup.rs
@@ -1,7 +1,7 @@
 use std::fs::OpenOptions;
 
 use crate::app::app::App;
-use crate::app::startup::args::{ARGS, Command, ImportType};
+use crate::app::startup::args::{Command, ImportType, ARGS};
 use crate::panic_error;
 use crate::request::collection::CollectionFileFormat;
 
@@ -18,20 +18,26 @@ impl App<'_> {
 
         if let Some(command) = &ARGS.command {
             match command {
-                Command::Import { import_type} => match import_type {
-                    ImportType::Postman { 
+                Command::Import { import_type } => match import_type {
+                    ImportType::Postman {
                         import_path,
-                        max_depth
+                        max_depth,
                     } => self.import_postman_collection(&import_path, max_depth.unwrap_or(99)),
-                    
+
                     ImportType::Curl {
                         import_path,
                         collection_name,
                         request_name,
                         recursive,
-                        max_depth
-                    } => self.import_curl_file(&import_path, collection_name, request_name, recursive, max_depth.unwrap_or(99))
-                }
+                        max_depth,
+                    } => self.import_curl_file(
+                        &import_path,
+                        collection_name,
+                        request_name,
+                        recursive,
+                        max_depth.unwrap_or(99),
+                    ),
+                },
             }
         }
 
@@ -41,7 +47,10 @@ impl App<'_> {
     fn parse_app_directory(&mut self) {
         let paths = match ARGS.directory.read_dir() {
             Ok(paths) => paths,
-            Err(e) => panic_error(format!("Directory \"{}\" not found\n\t{e}", ARGS.directory.display()))
+            Err(e) => panic_error(format!(
+                "Directory \"{}\" not found\n\t{e}",
+                ARGS.directory.display()
+            )),
         };
 
         for path in paths {
@@ -55,19 +64,15 @@ impl App<'_> {
 
             println!("Checking: {}", path.display());
 
-            if file_name.ends_with(".json") {
+            if file_name.ends_with("-atac.json") {
                 self.set_collections_from_file(path, CollectionFileFormat::Json);
-            }
-            else if file_name.ends_with(".yaml") {
+            } else if file_name.ends_with("-atac.yaml") {
                 self.set_collections_from_file(path, CollectionFileFormat::Yaml);
-            }
-            else if file_name.starts_with(".env.") {
+            } else if file_name.starts_with(".env.") {
                 self.add_environment_from_file(path)
-            }
-            else if file_name == "atac.toml" {
+            } else if file_name == "atac.toml" {
                 self.parse_config_file(path);
-            }
-            else if file_name == "atac.log" {
+            } else if file_name == "atac.log" {
                 println!("Nothing to parse here")
             }
 
@@ -78,9 +83,14 @@ impl App<'_> {
     fn create_log_file(&mut self) {
         let path = ARGS.directory.join("atac.log");
 
-        let log_file = match OpenOptions::new().write(true).create(true).truncate(true).open(path) {
+        let log_file = match OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)
+        {
             Ok(log_file) => log_file,
-            Err(e) => panic_error(format!("Could not open log file\n\t{e}"))
+            Err(e) => panic_error(format!("Could not open log file\n\t{e}")),
         };
 
         self.log_file = Some(log_file);


### PR DESCRIPTION
In my issue at #91 , I looked into the issue at why atac kept on qutting when a json file already exists in the directory, the ```set_collection_file``` now looks for a file ending with ```atac.json``` . But this is a very noob approach, just cause you would have to rename the json file and add the ```-atac``` prefix to the collection file and i can't seem to find where the name is being made.