### PR TITLE
Cancel request

### DIFF
--- a/key_bindings_templates/default_key_bindings.toml
+++ b/key_bindings_templates/default_key_bindings.toml
@@ -84,6 +84,7 @@ request_settings = "s"
 next_view = "v"
 
 send_request = "Space"
+cancel_request = "Ctrl-c"
 alt_send_request = "Ctrl-Enter"
 
 [keybindings.request_selected.param_tabs]

--- a/src/app/app_logic/request/cancel.rs
+++ b/src/app/app_logic/request/cancel.rs
@@ -1,0 +1,18 @@
+use crate::app::app::App;
+
+impl App<'_> {
+    pub async fn cancel_request(&mut self) {
+        let local_selected_request = self.get_selected_request_as_local();
+
+        let selected_request = local_selected_request.write();
+
+        if let Some(task) = &selected_request.abort_tx
+        {
+            if let Ok(task) = task.lock() {
+                let _ = task.send(true);
+            }
+        }
+
+        self.write_to_log_file("canceling request".to_string(), self.state.to_string());
+    }
+}

--- a/src/app/app_logic/request/mod.rs
+++ b/src/app/app_logic/request/mod.rs
@@ -4,6 +4,7 @@ pub mod headers;
 pub mod method;
 pub mod query_params;
 pub mod send;
+pub mod cancel;
 pub mod settings;
 pub mod url;
 pub(super) mod utils;

--- a/src/app/app_logic/request/send.rs
+++ b/src/app/app_logic/request/send.rs
@@ -297,11 +297,20 @@ impl App<'_> {
                     }
                 };
 
+                let timeout = tokio::time::sleep(Duration::from_secs(30));
+
                 let mut response = tokio::select! {
                     _ = cancel_watcher => {
                         elapsed_time = request_start.elapsed();
                         RequestResponse {
                             content: Some(ResponseContent::Body("Request canceled".to_string())),
+                            ..Default::default()
+                        }
+                    }
+                    _ = timeout => {
+                        elapsed_time = request_start.elapsed();
+                        RequestResponse {
+                            content: Some(ResponseContent::Body("Request timed out".to_string())),
                             ..Default::default()
                         }
                     }

--- a/src/app/app_states.rs
+++ b/src/app/app_states.rs
@@ -281,6 +281,7 @@ impl AppState {
                     NextView(EventKeyBinding::new(vec![key_bindings.request_selected.next_view], "Next view", None)),
 
                     SendRequest(EventKeyBinding::new(vec![key_bindings.request_selected.send_request, key_bindings.request_selected.alt_send_request], "Send request", Some("Send"))),
+                    CancelRequest(EventKeyBinding::new(vec![key_bindings.request_selected.cancel_request], "Cancel request", Some("Cancel"))),
 
                     NextEnvironment(EventKeyBinding::new(vec![key_bindings.main_menu.next_environment], "Next environment", None)),
                     DisplayCookies(EventKeyBinding::new(vec![key_bindings.main_menu.display_cookies], "Display cookies", None)),

--- a/src/app/events.rs
+++ b/src/app/events.rs
@@ -100,6 +100,7 @@ pub enum AppEvent {
     NextView(EventKeyBinding),
 
     SendRequest(EventKeyBinding),
+    CancelRequest(EventKeyBinding),
 
     /* Param tabs */
 
@@ -465,6 +466,7 @@ impl App<'_> {
 
                 NextView(_) => self.next_request_view(),
                 SendRequest(_) => self.send_request().await,
+                CancelRequest(_) => self.cancel_request().await,
 
                 /* Param tabs */
 
@@ -826,6 +828,7 @@ impl AppEvent {
             EditSettings(event_key_bindings) |
             NextView(event_key_bindings) |
             SendRequest(event_key_bindings) |
+            CancelRequest(event_key_bindings) |
             NextParamTab(event_key_bindings) |
             ModifyRequestAuthMethod(event_key_bindings) |
             ModifyRequestBodyContentType(event_key_bindings) |

--- a/src/app/files/key_bindings.rs
+++ b/src/app/files/key_bindings.rs
@@ -97,6 +97,7 @@ nest! {
             pub next_view: KeyCombination,
 
             pub send_request: KeyCombination,
+            pub cancel_request: KeyCombination,
             pub alt_send_request: KeyCombination,
             
             pub param_tabs: #[derive(Copy, Clone, Deserialize)] pub struct ParamTabs {
@@ -221,6 +222,7 @@ impl Default for KeyBindings {
                 // https://github.com/crossterm-rs/crossterm/issues/685
                 send_request: key!(space),
                 alt_send_request: key!(ctrl-enter),
+                cancel_request: key!(ctrl-c),
 
                 param_tabs: ParamTabs {
                     change_auth_method: key!(ctrl-a),

--- a/src/request/request.rs
+++ b/src/request/request.rs
@@ -1,7 +1,10 @@
+use std::sync::{Arc, Mutex};
+
 use lazy_static::lazy_static;
 use ratatui::prelude::{Line, Modifier, Span};
 use ratatui::style::Stylize;
 use serde::{Deserialize, Serialize};
+use tokio::sync::watch::Sender;
 use tui_tree_widget::TreeItem;
 
 use crate::app::app::App;
@@ -27,6 +30,8 @@ pub struct Request {
     #[serde(skip)]
     pub response: RequestResponse,
 
+    #[serde(skip)]
+    pub abort_tx: Option<Arc<Mutex<Sender<bool>>>>,
     #[serde(skip)]
     pub is_pending: bool
 }


### PR DESCRIPTION
Closes https://github.com/Julien-cpsn/ATAC/issues/82

I allowed for request cancellation with Ctrl-c
Also, in that issue, a timeout of 30s is mentioned, but I tested & looked at the code, and I couldn't find any timeout, so I implemented it, reusing the cancellation code
![image](https://github.com/user-attachments/assets/bec96ead-eacc-44a9-9d8e-030136760944)
![image](https://github.com/user-attachments/assets/d86962d6-3cc9-4b20-986a-c64426e8099d)

Also, the send_request() function is getting quite large, I kinda wanted to refactor it, and spread the logic over smaller functions, but felt rude to perform a refactor on a first pull request. Might do it if you are fine with it.

I appreciate the work you have put into this terminal app - thank you!