### PR TITLE
Accept invalid certs config

### DIFF
--- a/src/app/app_logic/request/send.rs
+++ b/src/app/app_logic/request/send.rs
@@ -35,6 +35,7 @@ impl App<'_> {
             }
 
             let mut client_builder = ClientBuilder::new()
+                .danger_accept_invalid_certs(selected_request.settings.accept_invalid_certs)
                 .default_headers(HeaderMap::new())
                 .referer(false);
 

--- a/src/request/settings.rs
+++ b/src/request/settings.rs
@@ -6,7 +6,6 @@ pub struct RequestSettings {
     pub allow_redirects: bool,
     pub store_received_cookies: bool,
     pub pretty_print_response_content: bool,
-    #[serde(default)]
     pub accept_invalid_certs: bool,
 }
 

--- a/src/request/settings.rs
+++ b/src/request/settings.rs
@@ -5,7 +5,9 @@ pub struct RequestSettings {
     pub use_config_proxy: bool,
     pub allow_redirects: bool,
     pub store_received_cookies: bool,
-    pub pretty_print_response_content: bool
+    pub pretty_print_response_content: bool,
+    #[serde(default)]
+    pub accept_invalid_certs: bool,
 }
 
 impl Default for RequestSettings {
@@ -15,6 +17,7 @@ impl Default for RequestSettings {
             allow_redirects: true,
             store_received_cookies: true,
             pretty_print_response_content: true,
+            accept_invalid_certs: false,
         }
     }
 }
@@ -26,6 +29,7 @@ impl RequestSettings {
             (String::from("Allow redirects"), self.allow_redirects),
             (String::from("Store received cookies"), self.store_received_cookies),
             (String::from("Pretty print response content"), self.pretty_print_response_content),
+            (String::from("Accept invalid certs"), self.accept_invalid_certs),
         ]
     }
 
@@ -36,6 +40,8 @@ impl RequestSettings {
                 "Allow redirects" => self.allow_redirects = *setting_value,
                 "Store received cookies" => self.store_received_cookies = *setting_value,
                 "Pretty print response content" => self.pretty_print_response_content = *setting_value,
+                "Accept invalid certs" => self.accept_invalid_certs = *setting_value,
+
                 _ => {}
             }
         }


### PR DESCRIPTION
Closes https://github.com/Julien-cpsn/ATAC/issues/98

Added a config to allow for insecure certificates, disabled by default.

I had to use #[serde(default)] on the field, so that the serde parser didn't complain and crash when reading an older config, and instead, just puts false. Don't know if there is some other special way you prefer to do config migrations.