### PR TITLE
Fix shell completions output directory

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -121,8 +121,16 @@ pub struct GlobalArgs {
 lazy_static! {
     pub static ref ARGS: GlobalArgs = {
         let args = Args::parse();
-        
-        let directory = match args.directory {
+
+        let completion_directory = if let Some(Command::Completions(ref completion_args)) = args.command {
+            completion_args.output_directory.clone().or_else(|| {
+                panic_error("No directory provided.");
+            })
+        } else {
+            None
+        };
+
+        let directory = match args.directory.or(completion_directory) {
             // If a directory was provided with a CLI argument
             Some(arg_directory) => expand_tilde(arg_directory),
             // If no directory was provided with the CLI


### PR DESCRIPTION
I realized the shell completions generation was added in the last release so I have it a try for the Arch package:

```shell
$ atac completions -h

atac completions [OPTIONS] <SHELL> [OUTPUT_DIRECTORY]

$ atach completions bash target

error: unexpected argument '--directory' found
```

> Uhh, what?

It turns out `--directory` argument was necessary for all cases so the correct command would be:

```shell
$ atac completions --directory target completions bash
```

I don't find this intuitive - and it clashes with the help message. So I fixed this in this PR and made the following possible:

```shell
$ atac completions bash target

Completions file generated into "target"
```

Also, it shows an error if you don't provide any directories as the trailing argument. (We can probably improve the error message there so LMK)
