### PR TITLE
feat: continuous deployment for docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.dockerignore
+Dockerfile
+
+.idea
+/target
+
+*.ps1
+
+.gitignore
+
+/.github
+/base_collections
+/gifs
+/import-tests
+/.typos.toml
+LICENSE
+README.md

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -30,7 +30,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_NAME }}
-
+          tags: |
+            # When the main branch gets updated, don't tag it as 'main'; instead, tag it as 'latest'
+            type=ref,event=branch,enable=false
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,58 @@
+name: Build Docker Image
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - .github/workflows/build-docker.yml
+      - Dockerfile
+  push:
+    branches: [ "main" ]
+  release:
+    types: [ "published" ]
+
+env:
+  PUSH_IMAGE: false
+  IMAGE_NAME: Julien-cpsn/ATAC
+  RUST_VERSION: "1.79"
+
+jobs:
+  build-and-publish:
+    name: Build and Publish Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        if: ${{ env.PUSH_IMAGE == true && github.event_name != 'pull_request' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+  
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          build-args: RUST_VERSION=${{ env.RUST_VERSION }}
+          push: ${{ env.PUSH_IMAGE == 'true' && github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Reuse docker build cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+ARG RUST_VERSION
+FROM lukemathwalker/cargo-chef:latest-rust-$RUST_VERSION-alpine3.20 AS base
+WORKDIR /app
+
+FROM base AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM base AS builder
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
+RUN cargo build --release --bin atac
+
+FROM alpine:3.20
+COPY --from=builder /app/target/release/atac /atac
+WORKDIR /app
+ENTRYPOINT [ "/atac" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG RUST_VERSION
-FROM lukemathwalker/cargo-chef:latest-rust-$RUST_VERSION-alpine3.20 AS base
+FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:latest-rust-$RUST_VERSION-alpine3.20 AS base
 WORKDIR /app
 
 FROM base AS planner
@@ -7,12 +7,22 @@ COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM base AS builder
-COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
-COPY . .
-RUN cargo build --release --bin atac
+ARG TARGETPLATFORM
+RUN case "$TARGETPLATFORM" in \
+	"linux/amd64") echo "x86_64-unknown-linux-musl" > rust_target.txt ;; \
+	"linux/arm64") echo "aarch64-unknown-linux-musl" > rust_target.txt ;; \
+	esac && \
+	# Install musl target
+	rustup target add $(cat rust_target.txt) && \
+	apk add zig && \
+	cargo install cargo-zigbuild
 
-FROM alpine:3.20
-COPY --from=builder /app/target/release/atac /atac
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --target $(cat rust_target.txt) --recipe-path recipe.json --zigbuild
+COPY . .
+RUN cargo zigbuild --release --target $(cat rust_target.txt) --bin atac && cp /app/target/$(cat rust_target.txt)/release/atac /atac
+
+FROM alpine:3.20 AS runtime
+COPY --from=builder /atac /atac
 WORKDIR /app
 ENTRYPOINT [ "/atac" ]


### PR DESCRIPTION
**Closes #96** 

### Usage

The workflow is currently configured to be build-only mode. To enable pushing the image to Docker Hub, you'll need to:

1. Set the `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` variables in the repository secrets.
2. Set the `PUSH_IMAGE` variable to `true` (or remove it entirely) in `.github/workflows/build-docker.yml`.

Once configured, the workflow will automatically push the image to Docker Hub when:

1. The `main` branch is updated, or
2. A release is published.


### Changes

- Added a Dockerfile that builds the app using [cargo-chef](https://github.com/LukeMathWalker/cargo-chef) to optimize Docker build caching. On a clean build (e.g., the first time this workflow runs or when dependencies are updated), it takes around 15-20 minutes to complete. If dependencies are cached, the build time reduces to ~5 minutes.
- Integrated [cargo-zigbuild](https://github.com/rust-cross/cargo-zigbuild) to build a multi-platform image supporting both `linux/amd64` and `linux/arm64`. It should be straightforward to add other targets to the build process.

### Limitations

- The final build command `cargo zigbuild --release ...` seems to execute every time, and I'm not sure why this happens.
- The `cargo-chef` Docker image currently supports only `linux/amd64` and `linux/arm64`. To support other platforms, the Dockerfile needs to be adjusted, by using a different base image and adding `cargo install cargo-chef`.

---

Let me know if the docker usage should be included in README, I'll try to add it! :smiley: