### PR TITLE
scripting-support: add generate_signed_jwt JS-native method to script…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,7 @@ dependencies = [
  "dirs",
  "image",
  "indexmap",
+ "jsonwebtoken",
  "jsonxf",
  "lazy_static",
  "nestify",
@@ -1785,6 +1786,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
+dependencies = [
+ "base64 0.21.7",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "jsonxf"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2314,6 +2330,16 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -3268,6 +3294,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ base64 = "=0.22.1"
 regex = "=1.10.6"
 chrono = { version = "=0.4.38", default-features = false, features = ["now"] }
 uuid = { version = "=1.10.0", features = ["v4", "v7"] }
+jsonwebtoken = "9.3.0"
 
 # Tracing
 tracing = { version = "=0.1.40", features = ["async-await"] }

--- a/src/app/business_logic/request/jwt.rs
+++ b/src/app/business_logic/request/jwt.rs
@@ -1,0 +1,27 @@
+extern crate jsonwebtoken as jwt;
+use std::collections::HashMap;
+
+use jwt::{Algorithm, encode, EncodingKey, Header};
+use serde_json::Value;
+
+pub fn get_signing_key(private_key_string: &str) -> EncodingKey {
+    let private_key = private_key_string.as_bytes();
+    let signing_key = EncodingKey::from_rsa_pem(private_key).unwrap();
+    signing_key
+}
+
+pub fn generate_jwt_token(private_key_string: &str, claims: &str, alg: Option<Algorithm>, kid: Option<String>) -> String {
+    let encoding_key = get_signing_key(private_key_string);
+    let algorithm = match alg {
+        Some(alg) => alg,
+        None => Algorithm::RS384
+    };
+
+    let mut header = Header::new(algorithm);
+    header.kid = kid;
+
+    let payload: HashMap<String, Value> = serde_json::from_str(claims).unwrap();
+
+    let token = encode(&header, &payload, &encoding_key).unwrap();
+    token
+}

--- a/src/app/business_logic/request/mod.rs
+++ b/src/app/business_logic/request/mod.rs
@@ -7,3 +7,5 @@ pub mod auth;
 pub mod headers;
 pub mod body;
 pub mod scripts;
+pub mod script_support;
+pub mod jwt;

--- a/src/app/business_logic/request/script_support.rs
+++ b/src/app/business_logic/request/script_support.rs
@@ -1,0 +1,35 @@
+use boa_engine::{JsValue, JsResult, JsString, Context};
+use jsonwebtoken::Algorithm;
+
+use super::jwt::generate_jwt_token;
+
+pub fn generate_signed_jwt(_this: &JsValue, args: &[JsValue], _ctx: &mut Context) -> JsResult<JsValue> {
+    let private_key_string: &str = &args.get(0).unwrap().as_string().unwrap().to_std_string().unwrap();
+    let claims: &str = &args.get(1).unwrap().as_string().unwrap().to_std_string().unwrap();
+    let alg = args.get(2).map(|arg| arg.as_string().unwrap());
+    let kid = args.get(3).map(|arg| arg.as_string().unwrap()).unwrap().to_std_string().unwrap();
+
+    let rust_alg = match alg {
+        Some(alg) => {
+            let alg_str: &str = &alg.to_std_string().unwrap();
+            match alg_str {
+                "HS256" => Some(Algorithm::HS256),
+                "HS384" => Some(Algorithm::HS384),
+                "HS512" => Some(Algorithm::HS512),
+                "RS256" => Some(Algorithm::RS256),
+                "RS384" => Some(Algorithm::RS384),
+                "RS512" => Some(Algorithm::RS512),
+                "ES256" => Some(Algorithm::ES256),
+                "ES384" => Some(Algorithm::ES384),
+                "PS256" => Some(Algorithm::PS256),
+                "PS384" => Some(Algorithm::PS384),
+                "PS512" => Some(Algorithm::PS512),
+                _ => None
+            }
+        },
+        None => None
+    };
+
+    let token = generate_jwt_token(private_key_string, claims, rust_alg, Some(kid));
+    Ok(JsValue::String(JsString::from(token)))
+}

--- a/src/app/business_logic/request/scripts.rs
+++ b/src/app/business_logic/request/scripts.rs
@@ -1,4 +1,4 @@
-use boa_engine::{Context, Source};
+use boa_engine::{Context, JsString, NativeFunction, Source};
 use indexmap::IndexMap;
 use tracing::{info, trace};
 
@@ -6,6 +6,8 @@ use crate::app::app::App;
 use crate::models::request::Request;
 use crate::models::response::RequestResponse;
 use crate::models::scripts::ScriptType;
+
+use super::script_support::generate_signed_jwt;
 
 impl App<'_> {
     pub fn modify_request_script(&mut self, collection_index: usize, request_index: usize, script_type: &ScriptType, script: Option<String>) -> anyhow::Result<()> {
@@ -48,6 +50,7 @@ function pretty_print(data) {
 pub fn execute_pre_request_script(user_script: &String, request: &Request, env: Option<IndexMap<String, String>>) -> (Option<Request>, Option<IndexMap<String, String>>, String) {
     // Instantiate the execution context
     let mut context = Context::default();
+    context.register_global_callable(JsString::from("generate_signed_jwt"), 0, NativeFunction::from_fn_ptr(generate_signed_jwt)).unwrap();
 
     let request_json = serde_json::to_string(request).unwrap();
     let env_json = match &env {
@@ -93,6 +96,7 @@ pub fn execute_pre_request_script(user_script: &String, request: &Request, env: 
 pub fn execute_post_request_script(user_script: &String, response: &RequestResponse, env: Option<IndexMap<String, String>>) -> (Option<RequestResponse>, Option<IndexMap<String, String>>, String) {
     // Instantiate the execution context
     let mut context = Context::default();
+    context.register_global_callable(JsString::from("generate_signed_jwt"), 0, NativeFunction::from_fn_ptr(generate_signed_jwt)).unwrap();
 
     let response_json = serde_json::to_string(response).unwrap();
     let env_json = match &env {


### PR DESCRIPTION
… env

Currently, it's not possible to generate a signed JWT token to use for authrozation, either through native rust functionality in the ATAC app, or through the JS scripting environment.

This PR generates a new rust-native method (so can be shared for more rust-native JWT features) to generate a signed JWT. It then creates a boa_engine compatible wrapper around that rust method to inject it in to the available scope for the JS scripts users may write.

Testing: