### PR TITLE
docs: :memo: cargo installation command changed in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The philosophy of ATAC is to be free, account-less, and offline for now and fore
 
 Simply use:
 ```shell
-cargo install atac
+cargo install atac --locked
 ```
 
 <a href="https://archlinux.org/packages/extra/x86_64/atac/">


### PR DESCRIPTION
"cargo install atac" sometimes not working because of crates that relies on may update without even realizing, that's why "cargo install atac --locked" should be used

related to: https://github.com/Julien-cpsn/ATAC/issues/111