### PR TITLE
Updated vim_key_bindings.toml because of a small error

### DIFF
--- a/example_resources/key_bindings/vim_key_bindings.toml
+++ b/example_resources/key_bindings/vim_key_bindings.toml
@@ -17,8 +17,8 @@ display_help = "Shift-h" # Take care to not overlap other inputs, the help can b
 
 # Collection name, request name, URL, Header, Query param, Basic Auth, Bearer Token
 [keybindings.generic.text_inputs.text_input]
-cancel = "Esc"
 confirm = "Enter"
+cancel = "Esc"
 
 delete_backward = "Delete"
 delete_forward = "Backspace"


### PR DESCRIPTION
if `confirm =  "Enter"` isn't first, ATAC throws an error

```
Error:
        Could not parse key bindings file
        TOML parse error at line 19, column 1
   |
19 | [keybindings.generic.text_inputs.text_input]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
missing field `confirm`
```
