### PR TITLE
Fixed app crash if response body fails to decode

### DIFF
--- a/src/app/business_logic/request/send.rs
+++ b/src/app/business_logic/request/send.rs
@@ -372,7 +372,10 @@ pub async fn send_request(prepared_request: reqwest_middleware::RequestBuilder, 
                         })
                     },
                     false => {
-                        let mut result_body = response.text().await.unwrap();
+                        let mut result_body = match response.text().await {
+                            Ok(body) => body,
+                            Err(error) => error.to_string()
+                        };
 
                         // If a file format has been found in the content-type header
                         if let Some(file_format) = find_file_format_in_content_type(&headers) {


### PR DESCRIPTION
Hi! I ran into a trouble while developing a backend server and testing image uploading feature. Due to some internal issue server was sending incorrect response somehow and app crashed with the error down below. Just a small tweak so at least app doesn't crash.
```trace
thread 'tokio-runtime-worker' panicked at src/app/business_logic/request/send.rs:362:69:
called `Result::unwrap()` on an `Err` value: reqwest::Error { kind: Decode, source: hyper::Error(Body, "connection error") }
```