### PR TITLE
fix(multipart form): fixing bug that prints true/false on random places

### DIFF
--- a/src/app/business_logic/request/http/body.rs
+++ b/src/app/business_logic/request/http/body.rs
@@ -130,7 +130,6 @@ impl App<'_> {
                 None => {
                     let state = !form[row].enabled;
                     // Better user feedback
-                    println!("{state}");
                     state
                 },
                 Some(state) => state


### PR DESCRIPTION
The bug is caused by the toggle_form_data func printing the state value (which is boolean) in the terminal

fix #130