### PR TITLE
fix: prevent last position underflow

### DIFF
--- a/src/app/business_logic/collection.rs
+++ b/src/app/business_logic/collection.rs
@@ -43,11 +43,11 @@ impl App<'_> {
         let file_format = self.config.get_preferred_collection_file_format();
         
         let collections_len = self.collections.len();
-        let last_position = if collections_len == 0 {
-            None
-        } else {
-            Some(collections_len - 1)
+        let last_position = match collections_len == 0 {
+            true => None,
+            false => Some(collections_len - 1),
         };
+        
         let new_collection = Collection {
             name: new_collection_name.clone(),
             last_position,


### PR DESCRIPTION
Fixes the last position underflow that occurs when creating a new collection when no other is present. This used to panic in debug mode. 

Note that I do not fully understand why we need to store `last_position` so this fix is a bit of a shot in the dark. Also during testing I was able to induce a different panic:

```
thread 'main' (35020) panicked at src/app/business_logic/request/utils.rs:10:70:
called `Option::unwrap()` on a `None` 
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I did not look into if the two issues are related or not.

Edit: I have not been able to reproduce the panic. I think they should not be related.